### PR TITLE
Building docker image with CI pipelines

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -45,3 +45,12 @@ jobs:
       - name: Testing
         working-directory: ./build
         run: ctest
+
+      - name: Building docker image
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/autocomplete:latest .
+
+      - name: Dockerhub Authentication
+        run: docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Publishing image to Container Registry
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/autocomplete:latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -57,4 +57,5 @@ jobs:
         run: docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Publishing image to Container Registry
+        if: github.ref == 'refs/heads/master'
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/autocomplete:latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -46,6 +46,10 @@ jobs:
         working-directory: ./build
         run: ctest
 
+      - name: Build binary dictionary
+        working-directory: build
+        run: chmod +x build && ./build ef_type1 ../test_data/trec_05_efficiency_queries/trec_05_efficiency_queries.completions -o trec_05.ef_type1.bin
+
       - name: Building docker image
         run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/autocomplete:latest .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM alpine:latest
+FROM ubuntu:latest
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+EXPOSE 8000
 
-USER appuser
+RUN groupadd appgroup && useradd appuser -G appgroup
 
 COPY ./build /app
 
 WORKDIR /app
+
+RUN chmod +x web_server
+
+USER appuser
 
 CMD ["./web_server", "8000", "trec_05.ef_type1.bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+USER appuser
+
+COPY ./build /app
+
+WORKDIR /app
+
+CMD ["./web_server", "8000", "trec_05.ef_type1.bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,22 @@ EXPOSE 8000
 
 RUN groupadd appgroup && useradd appuser -G appgroup
 
-COPY ./build /app
+COPY . /src
 
 WORKDIR /app
 
-RUN chmod +x web_server
+RUN apt update && apt install -y cmake g++ python
 
-# USER appuser
+RUN cmake /src && cmake --build .
+
+RUN chmod +x web_server && chmod +x build
+
+RUN ./build ef_type1 /src/test_data/trec_05_efficiency_queries/trec_05_efficiency_queries.completions -o trec_05.ef_type1.bin
+
+RUN apt purge -y cmake g++ python
+
+RUN rm -rf /src
+
+USER appuser
 
 CMD ["./web_server", "8000", "trec_05.ef_type1.bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /app
 
 RUN chmod +x web_server
 
-USER appuser
+# USER appuser
 
 CMD ["./web_server", "8000", "trec_05.ef_type1.bin"]

--- a/README.md
+++ b/README.md
@@ -182,3 +182,15 @@ Live demo <a name="demo"></a>
 
 Start the web server with the program `./web_server <port> <index_filename>` and access the demo at
 `localhost:<port>`.
+
+Use a prebuilt docker image
+----------
+
+The following command pulls a prebuilt docker image and runs it locally.
+
+```bash
+docker pull jermp/autocomplete
+docker run -p 8000:8000 -d jermp/autocomplete
+```
+
+The demo can be accessed at [http://localhost:8000](http://localhost:8000)


### PR DESCRIPTION
All the compiled executable files get packed into single a docker image, which is then published to Dockerhub.
Newcomers don't need to clone, install dependencies, compile now; 
instead they can run these simple commands
```bash
docker pull jermp/autocomplete
docker run -p 8000:8000 -d jermp/autocomplete
```