### PR TITLE
WIP: hybrid_topk implementation

### DIFF
--- a/include/autocomplete.hpp
+++ b/include/autocomplete.hpp
@@ -86,19 +86,26 @@ struct autocomplete {
         m_pool.scores().clear();
 
         std::set<int> already_covered_scores;
+        uint32_t num_completions = 0;
 
         for (int i = 0; i < int(pool_scores_prefix_topk.size()); ++i) {
-            m_pool.scores().push_back(pool_scores_prefix_topk[i]);
-            already_covered_scores.insert(pool_scores_prefix_topk[i]);
+            if (already_covered_scores.find(pool_scores_prefix_topk[i]) == already_covered_scores.end()) {
+                m_pool.scores().push_back(pool_scores_prefix_topk[i]);
+                already_covered_scores.insert(pool_scores_prefix_topk[i]);
+                num_completions++;
+            } else {
+                std::cout << "Ignoring score " << pool_scores_prefix_topk[i] << " to avoid duplicates" << std::endl;
+            }
         }
         for (int i = 0; i < int(pool_scores_conjunctive_topk.size()); ++i) {
             if (already_covered_scores.find(pool_scores_conjunctive_topk[i]) == already_covered_scores.end()) {
                 m_pool.scores().push_back(pool_scores_conjunctive_topk[i]);
+                already_covered_scores.insert(pool_scores_conjunctive_topk[i]);
+                num_completions++;
             } else {
                 std::cout << "Ignoring score " << pool_scores_conjunctive_topk[i] << " to avoid duplicates" << std::endl;
             }
         }
-        uint32_t num_completions = m_pool.scores().size();
 
         pool_scores_prefix_topk.clear();
         pool_scores_conjunctive_topk.clear();

--- a/include/autocomplete.hpp
+++ b/include/autocomplete.hpp
@@ -57,7 +57,9 @@ struct autocomplete {
         suffix_lex_range.begin += 1;
         suffix_lex_range.end += 1;
         range r = m_completions.locate_prefix(prefix, suffix_lex_range);
-        if (r.is_invalid()) return m_pool.begin();
+        if (r.is_invalid()) {
+            perform_prefix_search = false;
+        }
 
         uint32_t num_completions_for_prefix = 0;
         std::vector<id_type> pool_scores_prefix_topk;
@@ -68,6 +70,7 @@ struct autocomplete {
             for (size_t i = 0; i < m_pool.scores().size(); ++i) {
                 pool_scores_prefix_topk.push_back(m_pool.scores()[i]);
             }
+            m_pool.scores().clear();
         }
         probe.stop(1);
 

--- a/include/autocomplete.hpp
+++ b/include/autocomplete.hpp
@@ -35,6 +35,16 @@ struct autocomplete {
         fi_builder.build(m_forward_index);
     }
 
+    /**
+     * hybrid_topk implements autocompletion in the following order
+     * For getting top-k results form a given query:
+     *    fetch results from prefix search
+     *    if prefix results size < k
+     *       append the conjunctive search results (deduplication is done)
+     *
+     * Note: Reuse computation of prefix, suffix and suffix lex range
+     *
+     */
     template <typename Probe>
     iterator_type hybrid_topk(std::string const& query, const uint32_t k,
                               Probe& probe) {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -57,7 +57,8 @@ static void ev_handler(struct mg_connection* nc, int ev, void* p) {
             nop_probe probe;
             // auto it = topk_index.topk(query, k probe);
             // auto it = topk_index.prefix_topk(query, k, probe);
-            auto it = topk_index.conjunctive_topk(query, k, probe);
+//            auto it = topk_index.conjunctive_topk(query, k, probe);
+            auto it = topk_index.hybrid_topk(query, k, probe);
             if (it.empty()) {
                 data = "{\"suggestions\":[\"value\":\"\",\"data\":\"\"]}\n";
             } else {


### PR DESCRIPTION
**hybrid_topk** implements autocompletion in the following order
```
For getting top-k results form a given query:
      fetch results from prefix search
      if prefix results size < k
           append the conjunctive search results (deduplication is done)
```

Note: We are reusing computation of prefix, suffix and suffix lex range