### PR TITLE
util::find() issue fixed

### DIFF
--- a/include/util.hpp
+++ b/include/util.hpp
@@ -45,6 +45,7 @@ uint64_t find(S const& sequence, uint64_t id, uint64_t lo, uint64_t hi) {
                     return pos;
                 }
             }
+            break;
         }
         uint64_t pos = lo + ((hi - lo) >> 1);
         uint64_t val = sequence.access(pos);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -45,13 +45,17 @@ uint64_t find(S const& sequence, uint64_t id, uint64_t lo, uint64_t hi) {
                     return pos;
                 }
             }
-            break;
+//            break;
         }
         uint64_t pos = lo + ((hi - lo) >> 1);
         uint64_t val = sequence.access(pos);
         if (val == id) {
             return pos;
         } else if (val > id) {
+            // Rescuing hi from unsigned underflow
+            if (pos == 0) {
+                return global::not_found;
+            }
             hi = pos - 1;
         } else {
             lo = pos + 1;


### PR DESCRIPTION
When linear scanning doesn't find the target element, the control must
not go back to the binary search logic.

Signed-off-by: Rajdeep Roy Chowdhury <rrajdeeproychowdhury@gmail.com>